### PR TITLE
chore: add `curl` to require list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4.3 || ^8.0 || ^8.1",
+        "ext-curl": "*",
         "codeigniter4/shield": "dev-develop"
     },
     "require-dev": {


### PR DESCRIPTION
`ShieldOAuth` uses `CURLRequest` to connect with other OAuth services, so `curl` is required.