### PR TITLE
feat: add CLI command `make:oauthconfig`

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -84,6 +84,13 @@ public $globals = [
 Receive keys `client_id` and `client_secret` from each OAuth server.
 To connect to any of the servers, you need to receive`client_id` and `client_secret` from them and then set them in file `app/Config/ShieldOAuthConfig`.
 
+> **Note**
+> By default, there is no file `app/Config/ShieldOAuthConfig`. It is strongly recommended to set the keys to `app/Config/ShieldOAuthConfig`. This behavior will make sure that there will be no problems for the settings you have made in case of update `Shield OAuth`. To create it, you can use the following command:
+>
+> ```console
+> php spark make:oauthconfig
+> ```
+
 You can see [How To Get Keys](get_keys.md) for instructions on how to get the keys.
 
 ```php

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,6 +43,13 @@ public array $oauthConfigs = [
     // and other services...
 ```
 
+> **Note**
+> By default, there is no file `app/Config/ShieldOAuthConfig.php`. It is strongly recommended to set the keys to `app/Config/ShieldOAuthConfig.php`. This behavior will make sure that there will be no problems for the settings you have made in case of update `Shield OAuth`. To create it, you can use the following command:
+>
+> ```console
+> php spark make:oauthconfig
+> ```
+
 ### Step 5 : 
 Cancel filter for `Shield OAuth` routes.
 ```php

--- a/src/Commands/OAuthSetup.php
+++ b/src/Commands/OAuthSetup.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Datamweb\ShieldOAuth\Commands;
+
+use CodeIgniter\Shield\Commands\Setup\ContentReplacer;
+use CodeIgniter\Shield\Commands\Setup;
+
+class OAuthSetup extends Setup
+{
+    /**
+     * The group the command is lumped under
+     * when listing commands.
+     *
+     * @var string
+     */
+    protected $group = 'ShieldOAuth';
+
+    /**
+     * The Command's name
+     *
+     * @var string
+     */
+    protected $name = 'make:oauthconfig';
+
+    /**
+     * the Command's short description
+     *
+     * @var string
+     */
+    protected $description = 'Generate file ShieldOAuthConfig in path APPPATH\Config.';
+
+    /**
+     * the Command's usage
+     *
+     * @var string
+     */
+    protected $usage = 'make:oauthconfig';
+
+    /**
+     * the Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [];
+
+    /**
+     * the Command's Options
+     *
+     * @var array<string, string>
+     */
+    protected $options = [
+        '-f' => 'Force overwrite ALL existing files in destination.',
+    ];
+
+    /**
+     * The path to `Datamweb\ShieldOAuth\` src directory.
+     *
+     * @var string
+     */
+    protected $sourcePath;
+
+    protected $distPath = APPPATH;
+    private ContentReplacer $replacer;
+
+    /**
+     * Displays the help for the spark cli script itself.
+     */
+    public function run(array $params): void
+    {
+        $this->replacer = new ContentReplacer();
+
+        $this->sourcePath = __DIR__ . '/../';
+
+        $file     = 'Config/ShieldOAuthConfig.php';
+        $replaces = [
+            'namespace Datamweb\ShieldOAuth\Config;' => 'namespace Config;',
+            'use CodeIgniter\\Config\\BaseConfig;'   => 'use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig as OAuthConfig;',
+            'extends BaseConfig'                     => 'extends OAuthConfig',
+        ];
+
+        $this->copyAndReplace($file, $replaces);
+    }
+
+    /**
+     * @param string $file     Relative file path like 'Config/ShieldOAuthConfig.php'.
+     * @param array  $replaces [search => replace]
+     */
+    protected function copyAndReplace(string $file, array $replaces): void
+    {
+        $path = "{$this->sourcePath}/{$file}";
+
+        $content = file_get_contents($path);
+
+        $content = $this->replacer->replace($content, $replaces);
+
+        $this->writeFile($file, $content);
+    }
+
+}

--- a/src/Commands/OAuthSetup.php
+++ b/src/Commands/OAuthSetup.php
@@ -2,10 +2,19 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of Shield OAuth.
+ *
+ * (c) Datamweb <pooya_parsa_dadashi@yahoo.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
 namespace Datamweb\ShieldOAuth\Commands;
 
-use CodeIgniter\Shield\Commands\Setup\ContentReplacer;
 use CodeIgniter\Shield\Commands\Setup;
+use CodeIgniter\Shield\Commands\Setup\ContentReplacer;
 
 class OAuthSetup extends Setup
 {
@@ -97,5 +106,4 @@ class OAuthSetup extends Setup
 
         $this->writeFile($file, $content);
     }
-
 }


### PR DESCRIPTION
resolve #23 
This command allows the user to create file `app/Config/ShieldOAuthConfig.php` through the command line. With this method, if the user updates **ShieldOAuth**, the set information (including keys, etc.) will not be lost.