### PR TITLE
chore: add PHPStan

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Commands\\\\OAuthSetup\\:\\:copyAndReplace\\(\\) has parameter \\$replaces with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Commands/OAuthSetup.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Commands\\\\OAuthSetup\\:\\:\\$arguments type has no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Commands/OAuthSetup.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Commands\\\\OAuthSetup\\:\\:\\$distPath has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Commands/OAuthSetup.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Config\\\\Registrar\\:\\:Generators\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Config/Registrar.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to deprecated function random_string\\(\\)\\:
+The type \'basic\', \'md5\', and \'sha1\' are deprecated\\. They are not cryptographically secure\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Class Datamweb\\\\ShieldOAuth\\\\Controllers\\\\LoginModel not found\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Controllers\\\\OAuthController\\:\\:checkExistenceUser\\(\\) has parameter \\$find with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Controllers\\\\OAuthController\\:\\:syncingUserInfo\\(\\) has parameter \\$find with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Controllers\\\\OAuthController\\:\\:syncingUserInfo\\(\\) has parameter \\$updateFildes with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Access to an undefined property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\Basic\\\\AbstractOAuth\\:\\:\\$token\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/src/Libraries/Basic/AbstractOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\Basic\\\\AbstractOAuth\\:\\:fetchAccessTokenWithAuthCode\\(\\) has parameter \\$allGet with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/Basic/AbstractOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\Basic\\\\AbstractOAuth\\:\\:getColumnsName\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/Basic/AbstractOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\Basic\\\\AbstractOAuth\\:\\:getUserInfo\\(\\) has parameter \\$allGet with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/Basic/AbstractOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\Basic\\\\AbstractOAuth\\:\\:setColumnsName\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/Basic/AbstractOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to deprecated function random_string\\(\\)\\:
+The type \'basic\', \'md5\', and \'sha1\' are deprecated\\. They are not cryptographically secure\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:fetchAccessTokenWithAuthCode\\(\\) has parameter \\$allGet with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:setColumnsName\\(\\) has parameter \\$userInfo with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:setColumnsName\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:\\$API_CODE_URL has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:\\$API_TOKEN_URL has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:\\$API_USER_INFO_URL has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:\\$APPLICATION_NAME has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:\\$client has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GithubOAuth\\:\\:\\$config has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Variable \\$usersColumnsName might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GithubOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to deprecated function random_string\\(\\)\\:
+The type \'basic\', \'md5\', and \'sha1\' are deprecated\\. They are not cryptographically secure\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:fetchAccessTokenWithAuthCode\\(\\) has parameter \\$allGet with no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:setColumnsName\\(\\) has parameter \\$userInfo with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:setColumnsName\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:\\$API_CODE_URL has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:\\$API_TOKEN_URL has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:\\$API_USER_INFO_URL has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:\\$APPLICATION_NAME has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:\\$client has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property Datamweb\\\\ShieldOAuth\\\\Libraries\\\\GoogleOAuth\\:\\:\\$config has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Variable \\$usersColumnsName might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Libraries/GoogleOAuth.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,21 @@
+parameters:
+	tmpDir: build/phpstan
+	level: 6
+	paths:
+		- src/
+	bootstrapFiles:
+		- vendor/codeigniter4/framework/system/Test/bootstrap.php
+	excludePaths:
+		- app/Config/Routes.php
+		- app/Views/*
+	ignoreErrors:
+	universalObjectCratesClasses:
+		- CodeIgniter\Entity
+		- CodeIgniter\Entity\Entity
+		- Faker\Generator
+	scanDirectories:
+		- vendor/codeigniter4/framework/system/Helpers
+	dynamicConstantNames:
+		- APP_NAMESPACE
+		- CI_DEBUG
+		- ENVIRONMENT

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
+includes:
+	- phpstan-baseline.php
 parameters:
 	tmpDir: build/phpstan
 	level: 6

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -25,7 +25,7 @@ class Registrar
      *
      * @see https://codeigniter.com/user_guide/outgoing/view_decorators.html
      *
-     * @return array<string, array<int, string>>
+     * @return array<string, list<string>>
      */
     public static function View()
     {

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -18,9 +18,16 @@ use Datamweb\ShieldOAuth\Views\Decorators\ShieldOAuth;
 class Registrar
 {
     /**
+     * --------------------------------------------------------------------------
+     * Shield OAuth Decorator
+     * --------------------------------------------------------------------------
      * Register the ShieldOAuth decorator.
+     *
+     * @see https://codeigniter.com/user_guide/outgoing/view_decorators.html
+     *
+     * @return array<string, array<int, string>>
      */
-    public static function View(): array
+    public static function View()
     {
         return [
             'decorators' => [

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -27,7 +27,7 @@ class Registrar
      *
      * @return array<string, list<string>>
      */
-    public static function View()
+    public static function View(): array
     {
         return [
             'decorators' => [

--- a/src/Config/Routes.php
+++ b/src/Config/Routes.php
@@ -11,9 +11,18 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
+/**
+ * @var CodeIgniter\Router\RouteCollection $routes
+ */
 $routes->group('oauth', ['namespace' => '\Datamweb\ShieldOAuth\Controllers'], static function ($routes): void {
-    $routes->addPlaceholder('allOAuthList', service('ShieldOAuth')->allOAuth());
+    /** @var \Datamweb\ShieldOAuth\Libraries\Basic\ShieldOAuth $shieldOAuthLib */
+    $shieldOAuthLib = service('ShieldOAuth');
+
+    $routes->addPlaceholder('allOAuthList', $shieldOAuthLib->allOAuth());
     $routes->get('(:allOAuthList)', 'OAuthController::redirectOAuth/$1');
 
-    $routes->get(config('ShieldOAuthConfig')->call_back_route, 'OAuthController::callBack');
+    /** @var \Datamweb\ShieldOAuth\Config\ShieldOAuthConfig $config */
+    $config = config('ShieldOAuthConfig');
+
+    $routes->get($config->call_back_route, 'OAuthController::callBack');
 });

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -18,12 +18,24 @@ use Datamweb\ShieldOAuth\Libraries\Basic\ShieldOAuth;
 
 class Services extends BaseService
 {
+    /**
+     * -------------------------------------------------------
+     * Service Configuration file
+     * -------------------------------------------------------
+     * Create and share new class instances
+     *
+     * More Info @see https://codeigniter.com/user_guide/concepts/services.html
+     *
+     * @param mixed $getShared
+     *
+     * @return mixed|ShieldOAuth
+     */
     public static function ShieldOAuth($getShared = true)
     {
         if ($getShared) {
             return static::getSharedInstance('ShieldOAuth');
         }
 
-        return new ShieldOAuth(new ShieldOAuthConfig());
+        return new ShieldOAuth();
     }
 }

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -26,11 +26,9 @@ class Services extends BaseService
      *
      * More Info @see https://codeigniter.com/user_guide/concepts/services.html
      *
-     * @param mixed $getShared
-     *
      * @return mixed|ShieldOAuth
      */
-    public static function ShieldOAuth($getShared = true)
+    public static function ShieldOAuth(bool $getShared = true)
     {
         if ($getShared) {
             return static::getSharedInstance('ShieldOAuth');

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -25,10 +25,8 @@ class Services extends BaseService
      * Create and share new class instances
      *
      * More Info @see https://codeigniter.com/user_guide/concepts/services.html
-     *
-     * @return mixed|ShieldOAuth
      */
-    public static function ShieldOAuth(bool $getShared = true)
+    public static function ShieldOAuth(bool $getShared = true): ShieldOAuth
     {
         if ($getShared) {
             return static::getSharedInstance('ShieldOAuth');

--- a/src/Config/ShieldOAuthConfig.php
+++ b/src/Config/ShieldOAuthConfig.php
@@ -83,8 +83,8 @@ class ShieldOAuthConfig extends BaseConfig
      * --------------------------------------------------------------------------
      * Turn ON/OFF user data update
      *
-     * If the user is already registered, by default when trying to login, he/she information will be synchronized.
-     * if you want to cancel it, set false.
+     * If the user is already registered, by default when trying to login, their
+     * information will be synchronized. If you want to cancel it, set to false.
      */
     public bool $syncingUserInfo = true;
 
@@ -95,9 +95,9 @@ class ShieldOAuthConfig extends BaseConfig
      * Set your custom call-back name
      *
      * When the user login with his profile, the OAuth server directs him to the following path.
-     * So change this value only when you need to make an customez.
-     * By default it returns to the following path:
-     * http:\\localhost:8080\oauth\call-back
+     * So change this value only when you need to customize it.
+     * By default, it returns to the following path:
+     *      http://localhost:8080/oauth/call-back
      */
     public string $call_back_route = 'call-back';
 }

--- a/src/Config/ShieldOAuthConfig.php
+++ b/src/Config/ShieldOAuthConfig.php
@@ -17,6 +17,20 @@ use CodeIgniter\Config\BaseConfig;
 
 class ShieldOAuthConfig extends BaseConfig
 {
+    /**
+     * --------------------------------------------------------------------------
+     * OAuth Configs
+     * --------------------------------------------------------------------------
+     *
+     * Set keys and active any OAuth
+     *
+     * Here you can set the keys received from any OAuth servers.
+     * for more information on getting keys:
+     *
+     * @see https://github.com/datamweb/shield-oauth/blob/develop/docs/get_keys.md
+     *
+     * @var array<string, array<string, bool|string>>
+     */
     public array $oauthConfigs = [
         'github' => [
             'client_id'     => 'Get it from GitHub',
@@ -38,38 +52,52 @@ class ShieldOAuthConfig extends BaseConfig
         // ],
     ];
 
-    /*
-    * If you use different names for the columns in the users table, use the following settings.
-
-    * Data of Table "users":
-    * +----+----------+--------+...+------------+-----------+--------+
-    * | id | username | status |...| first_name | last_name | avatar |
-    * +----+----------+--------+...+------------+-----------+--------+
-    * In fact, you set in which column the information received from the services should be recorded.
-    * For example, the first name received from OAuth should be recorded in column 'first_name' of the 'users' table shield.
-    *
-    * NOTE :
-    *       This is suitable for those who have already installed the shield and created their own columns.
-    *       In this case, there is no need to execute `php spark migrate -n Datamweb\ShieldOAuth`.
-    *       Just set the following values with your table columns.
-    */
+    /**
+     * --------------------------------------------------------------------------
+     * Users Columns Name
+     * --------------------------------------------------------------------------
+     * If you use different names for the columns in the users table, use the following settings.
+     *
+     * Data of Table "users":
+     * +----+----------+--------+...+------------+-----------+--------+
+     * | id | username | status |...| first_name | last_name | avatar |
+     * +----+----------+--------+...+------------+-----------+--------+
+     * In fact, you set in which column the information received from the OAuth services should be recorded.
+     * For example, the first name received from OAuth should be recorded in column 'first_name' of the 'users' table shield.
+     * NOTE :
+     *       This is suitable for those who have already installed the shield and created their own columns.
+     *       In this case, there is no need to execute `php spark migrate -n Datamweb\ShieldOAuth`.
+     *       Just set the following values with your table columns.
+     *
+     * @var array<string, string>
+     */
     public array $usersColumnsName = [
         'first_name' => 'first_name',
         'last_name'  => 'last_name',
         'avatar'     => 'avatar',
     ];
 
-    /*
-    * If the user is already registered, by default when trying to login, he/she information will be synchronized.
-    * if you want to cancel it, set false.
-    */
+    /**
+     * --------------------------------------------------------------------------
+     * Syncing User Info
+     * --------------------------------------------------------------------------
+     * Turn ON/OFF user data update
+     *
+     * If the user is already registered, by default when trying to login, he/she information will be synchronized.
+     * if you want to cancel it, set false.
+     */
     public bool $syncingUserInfo = true;
 
-    /*
-    * When the user login with his profile, the OAuth server directs him to the following path.
-    * So change this value only when you need to make an order.
-    * By default it returns to the following path:
-    * http:\\localhost:8080\oauth\call-back
-    */
+    /**
+     * --------------------------------------------------------------------------
+     * Call Back Route
+     * --------------------------------------------------------------------------
+     * Set your custom call-back name
+     *
+     * When the user login with his profile, the OAuth server directs him to the following path.
+     * So change this value only when you need to make an customez.
+     * By default it returns to the following path:
+     * http:\\localhost:8080\oauth\call-back
+     */
     public string $call_back_route = 'call-back';
 }

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace Datamweb\ShieldOAuth\Controllers;
 
 use App\Controllers\BaseController;
+use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Entities\User;
 use Datamweb\ShieldOAuth\Libraries\Basic\ControllersInterface;
 
 class OAuthController extends BaseController implements ControllersInterface
 {
-    public function redirectOAuth(string $oauthName)
+    public function redirectOAuth(string $oauthName): RedirectResponse
     {
         // if user login
         if (auth()->loggedIn()) {
@@ -45,7 +46,7 @@ class OAuthController extends BaseController implements ControllersInterface
         return redirect()->to($redirectLink);
     }
 
-    public function callBack()
+    public function callBack(): RedirectResponse
     {
         // if user after callback request url
         if (! session('oauth_name')) {

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -16,6 +16,7 @@ namespace Datamweb\ShieldOAuth\Controllers;
 use App\Controllers\BaseController;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Models\LoginModel;
 use Datamweb\ShieldOAuth\Libraries\Basic\ControllersInterface;
 
 class OAuthController extends BaseController implements ControllersInterface

--- a/src/Database/Migrations/2022-10-20-182737_ShieldOAuth.php
+++ b/src/Database/Migrations/2022-10-20-182737_ShieldOAuth.php
@@ -14,16 +14,23 @@ declare(strict_types=1);
 namespace Datamweb\ShieldOAuth\Database\Migrations;
 
 use CodeIgniter\Database\Migration;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 
 class ShieldOAuth extends Migration
 {
+    private string $first_name;
+    private string $last_name;
+    private string $avatar;
+
     public function __construct()
     {
         parent::__construct();
 
-        $this->first_name = config('ShieldOAuthConfig')->usersColumnsName['first_name'];
-        $this->last_name  = config('ShieldOAuthConfig')->usersColumnsName['last_name'];
-        $this->avatar     = config('ShieldOAuthConfig')->usersColumnsName['avatar'];
+        /** @var ShieldOAuthConfig $config */
+        $config           = config(ShieldOAuthConfig::class);
+        $this->first_name = $config->usersColumnsName['first_name'];
+        $this->last_name  = $config->usersColumnsName['last_name'];
+        $this->avatar     = $config->usersColumnsName['avatar'];
     }
 
     public function up(): void

--- a/src/Libraries/Basic/ControllersInterface.php
+++ b/src/Libraries/Basic/ControllersInterface.php
@@ -13,9 +13,31 @@ declare(strict_types=1);
 
 namespace Datamweb\ShieldOAuth\Libraries\Basic;
 
+use CodeIgniter\HTTP\RedirectResponse;
+
 interface ControllersInterface
 {
-    public function redirectOAuth(string $oauthName);
+    /**
+     * -------------------------------------------------------------------------------------------
+     * Users Redirected to Request Their OAuth Identity
+     * -------------------------------------------------------------------------------------------
+     *
+     * The user is redirected to the specified URL for login to any OAuth service with credentials.
+     * Each OAuth service provides how to create a link for validation based on its instructions.
+     * For example, Github is explained here.
+     *
+     * @see https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity
+     */
+    public function redirectOAuth(string $oauthName): RedirectResponse;
 
-    public function callBack();
+    /**
+     * -------------------------------------------------------------------------------------------
+     * Call Back From Every OAuth Service
+     * -------------------------------------------------------------------------------------------
+     *
+     * User return after credentials are valid or invalid in each OAuth service
+     * If the user is valid in OAuth Service, the new user is registered or login if there is one in shield user table.
+     * Otherwise, error messages will be displayed.
+     */
+    public function callBack(): RedirectResponse;
 }

--- a/src/Libraries/Basic/ShieldOAuth.php
+++ b/src/Libraries/Basic/ShieldOAuth.php
@@ -65,7 +65,7 @@ class ShieldOAuth
             $files = $files->add(APPPATH . 'ThirdParty/shield-oauth/src/Libraries', false);
         } else {
             // Adds all Libraries files if install via composer
-            $files = $files->add(VENDORPATH . 'datamweb/shield-oauth/src/Libraries', false);
+            $files = $files->add(__DIR__ . '/..', false);
         }
         // For to detect custom OAuth
         if (is_dir(APPPATH . 'Libraries/ShieldOAuth')) {

--- a/src/Models/ShieldOAuthModel.php
+++ b/src/Models/ShieldOAuthModel.php
@@ -14,17 +14,22 @@ declare(strict_types=1);
 namespace Datamweb\ShieldOAuth\Models;
 
 use CodeIgniter\Shield\Models\UserModel;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 
 class ShieldOAuthModel extends UserModel
 {
     protected function initialize(): void
     {
         parent::initialize();
+
+        /** @var ShieldOAuthConfig $config */
+        $config = config(ShieldOAuthConfig::class);
+
         // Merge properties with parent
         $this->allowedFields = array_merge($this->allowedFields, [
-            config('ShieldOAuthConfig')->usersColumnsName['first_name'],
-            config('ShieldOAuthConfig')->usersColumnsName['last_name'],
-            config('ShieldOAuthConfig')->usersColumnsName['avatar'],
+            $config->usersColumnsName['first_name'],
+            $config->usersColumnsName['last_name'],
+            $config->usersColumnsName['avatar'],
         ]);
     }
 }


### PR DESCRIPTION
Supersedes #19

```console
$ vendor/bin/phpstan
Note: Using configuration file .../shield-oauth/phpstan.neon.dist.
 19/19 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                                            
 [OK] No errors                                           
```

Ignored errors:
```
 ------ --------------------------------------------------------------------------------------------------------------------------- 
  Line   Commands/OAuthSetup.php                                                                                                    
 ------ --------------------------------------------------------------------------------------------------------------------------- 
  55     Property Datamweb\ShieldOAuth\Commands\OAuthSetup::$arguments type has no value type specified in iterable type array.     
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                  
  73     Property Datamweb\ShieldOAuth\Commands\OAuthSetup::$distPath has no type specified.                                        
  99     Method Datamweb\ShieldOAuth\Commands\OAuthSetup::copyAndReplace() has parameter $replaces with no value type specified in  
         iterable type array.                                                                                                       
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                  
 ------ --------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  Line   Config/Registrar.php                                                                                                        
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  42     Method Datamweb\ShieldOAuth\Config\Registrar::Generators() return type has no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                   
 ------ ---------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------- 
  Line   Controllers/OAuthController.php                                                                                            
 ------ --------------------------------------------------------------------------------------------------------------------------- 
  111    Call to deprecated function random_string():                                                                               
         The type 'basic', 'md5', and 'sha1' are deprecated. They are not cryptographically secure.                                 
  123    Method Datamweb\ShieldOAuth\Controllers\OAuthController::checkExistenceUser() has parameter $find with no value type       
         specified in iterable type array.                                                                                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                  
  132    Method Datamweb\ShieldOAuth\Controllers\OAuthController::syncingUserInfo() has parameter $find with no value type          
         specified in iterable type array.                                                                                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                  
  132    Method Datamweb\ShieldOAuth\Controllers\OAuthController::syncingUserInfo() has parameter $updateFildes with no value type  
         specified in iterable type array.                                                                                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                  
  148    Class Datamweb\ShieldOAuth\Controllers\LoginModel not found.                                                               
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                                                        
 ------ --------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------- 
  Line   Libraries/Basic/AbstractOAuth.php                                                                                        
 ------ ------------------------------------------------------------------------------------------------------------------------- 
  20     Method Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth::fetchAccessTokenWithAuthCode() has parameter $allGet with no  
         value type specified in iterable type array.                                                                             
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                
  24     Method Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth::setColumnsName() return type has no value type specified in   
         iterable type array.                                                                                                     
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                
  28     Access to an undefined property Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth::$token.                              
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property                                     
  33     Access to an undefined property Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth::$token.                              
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property                                     
  36     Method Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth::getUserInfo() has parameter $allGet with no value type        
         specified in iterable type array.                                                                                        
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                
  43     Method Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth::getColumnsName() return type has no value type specified in   
         iterable type array.                                                                                                     
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                
 ------ ------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  Line   Libraries/GithubOAuth.php                                                                                                   
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  21     Property Datamweb\ShieldOAuth\Libraries\GithubOAuth::$API_CODE_URL has no type specified.                                   
  22     Property Datamweb\ShieldOAuth\Libraries\GithubOAuth::$API_TOKEN_URL has no type specified.                                  
  23     Property Datamweb\ShieldOAuth\Libraries\GithubOAuth::$API_USER_INFO_URL has no type specified.                              
  24     Property Datamweb\ShieldOAuth\Libraries\GithubOAuth::$APPLICATION_NAME has no type specified.                               
  26     Property Datamweb\ShieldOAuth\Libraries\GithubOAuth::$client has no type specified.                                         
  27     Property Datamweb\ShieldOAuth\Libraries\GithubOAuth::$config has no type specified.                                         
  48     Method Datamweb\ShieldOAuth\Libraries\GithubOAuth::fetchAccessTokenWithAuthCode() has parameter $allGet with no value type  
         specified in iterable type array.                                                                                           
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                   
  92     Method Datamweb\ShieldOAuth\Libraries\GithubOAuth::setColumnsName() has parameter $userInfo with no type specified.         
  92     Method Datamweb\ShieldOAuth\Libraries\GithubOAuth::setColumnsName() return type has no value type specified in iterable     
         type array.                                                                                                                 
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                   
  106    Call to deprecated function random_string():                                                                                
         The type 'basic', 'md5', and 'sha1' are deprecated. They are not cryptographically secure.                                  
  114    Variable $usersColumnsName might not be defined.                                                                            
 ------ ---------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  Line   Libraries/GoogleOAuth.php                                                                                                   
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  21     Property Datamweb\ShieldOAuth\Libraries\GoogleOAuth::$API_CODE_URL has no type specified.                                   
  22     Property Datamweb\ShieldOAuth\Libraries\GoogleOAuth::$API_TOKEN_URL has no type specified.                                  
  23     Property Datamweb\ShieldOAuth\Libraries\GoogleOAuth::$API_USER_INFO_URL has no type specified.                              
  24     Property Datamweb\ShieldOAuth\Libraries\GoogleOAuth::$APPLICATION_NAME has no type specified.                               
  26     Property Datamweb\ShieldOAuth\Libraries\GoogleOAuth::$client has no type specified.                                         
  27     Property Datamweb\ShieldOAuth\Libraries\GoogleOAuth::$config has no type specified.                                         
  48     Method Datamweb\ShieldOAuth\Libraries\GoogleOAuth::fetchAccessTokenWithAuthCode() has parameter $allGet with no value type  
         specified in iterable type array.                                                                                           
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                   
  92     Method Datamweb\ShieldOAuth\Libraries\GoogleOAuth::setColumnsName() has parameter $userInfo with no type specified.         
  92     Method Datamweb\ShieldOAuth\Libraries\GoogleOAuth::setColumnsName() return type has no value type specified in iterable     
         type array.                                                                                                                 
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                   
  107    Call to deprecated function random_string():                                                                                
         The type 'basic', 'md5', and 'sha1' are deprecated. They are not cryptographically secure.                                  
  115    Variable $usersColumnsName might not be defined.                                                                            
 ------ ---------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 37 errors  
```