### PR TITLE
Update 'username' field for 'newUser' process

### DIFF
--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -104,11 +104,11 @@ class GoogleOAuth extends AbstractOAuth
         if ($nameOfProcess === 'newUser') {
             return [
                 // users tbl                                    // OAuth
-                'username'                                    => $userInfo->given_name,
+                'username'                                    => $userInfo->email,
                 'email'                                       => $userInfo->email,
                 'password'                                    => random_string('crypto', 32),
                 'active'                                      => $userInfo->email_verified,
-                $this->config->usersColumnsName['first_name'] => $userInfo->name,
+                $this->config->usersColumnsName['first_name'] => $userInfo->given_name,
                 $this->config->usersColumnsName['last_name']  => $userInfo->family_name,
                 $this->config->usersColumnsName['avatar']     => $userInfo->picture,
             ];


### PR DESCRIPTION
Adjusted the 'username' field in the user data array for the 'newUser' process to ensure uniqueness. Now, 'username' is set to the user's email address, as it must be unique. The first_name has also been fixed, as it wasn't set to the correct value.