### PR TITLE
Update composer.json to use Shield v1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "require": {
         "php": "^7.4.3 || ^8.0 || ^8.1 || ^8.2",
         "ext-curl": "*",
-        "codeigniter4/shield": "v1.0.0"
+        "codeigniter4/shield": "1.0.0"
     },
     "require-dev": {
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.3.5",
-        "codeigniter4/shield": "v1.0.0",
+        "codeigniter4/shield": "1.0.0",
         "rector/rector": "0.18.13"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "require": {
         "php": "^7.4.3 || ^8.0 || ^8.1 || ^8.2",
         "ext-curl": "*",
-        "codeigniter4/shield": "dev-develop"
+        "codeigniter4/shield": "v1.0.0"
     },
     "require-dev": {
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.3.5",
-        "codeigniter4/shield": "dev-develop",
+        "codeigniter4/shield": "v1.0.0",
         "rector/rector": "0.18.13"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.3.5",
-        "codeigniter4/shield": "1.0.0",
+        "codeigniter4/shield": "^1.0",
         "rector/rector": "0.18.13"
     },
     "autoload": {


### PR DESCRIPTION
@datamweb I would like to keep use this package, but we would like to switch to latest stable version of shield, but then dev-develop is not meet. Can we use tagged version of Shield to be required ? Please take a look and propose other solution to this, maybe something more is needed to update. Thanks.