### PR TITLE
feat: add used env config for keys

### DIFF
--- a/docs/add_other_oauth.md
+++ b/docs/add_other_oauth.md
@@ -2,10 +2,12 @@
 
 Shield OAuth supports *Google OAuth* and *GitHub OAuth* out-of-the-box and also provides an easy way to connect any server that offers **OAuth** to it. This guide explains how to achieve this.
 
-- [Adding New OAuth to Shield OAuth](#adding-new-oauth-to-shield-oauth) 
+- [Adding New OAuth To Shield OAuth](#adding-new-oauth-to-shield-oauth)
   - [Setup Instruction](#setup-instruction)
     - [Command Setup](#command-setup)
     - [Manual Setup](#manual-setup)
+  - [Available Methods](#available-methods)
+  - [YahooOAuth Example Class](#yahoooauth-example-class)
 
 ## Setup Instruction
 
@@ -228,8 +230,8 @@ class YahooOAuth extends AbstractOAuth
 
         $this->config        = config('ShieldOAuthConfig');
         $this->callback_url  = base_url('oauth/' . $this->config->call_back_route);
-        $this->client_id     = $this->config->oauthConfigs['yahoo']['client_id'];
-        $this->client_secret = $this->config->oauthConfigs['yahoo']['client_secret'];
+        $this->client_id     = env('ShieldOAuthConfig.yahoo.client_id', $this->config->oauthConfigs['yahoo']['client_id']);
+        $this->client_secret = env('ShieldOAuthConfig.yahoo.client_secret', $this->config->oauthConfigs['yahoo']['client_secret']);
     }
 
     public function makeGoLink(string $state): string

--- a/docs/install.md
+++ b/docs/install.md
@@ -82,7 +82,14 @@ public $globals = [
 ## Set keys 
 
 Receive keys `client_id` and `client_secret` from each OAuth server.
-To connect to any of the servers, you need to receive`client_id` and `client_secret` from them and then set them in file `app/Config/ShieldOAuthConfig`.
+To connect to any of the servers, you need to receive`client_id` and `client_secret` from them and then set them in file **.env** Or `app/Config/ShieldOAuthConfig`.
+
+We suggest that you set the keys of each service in file **.env** instead of using **app/Config/ShieldOAuthConfig**. For example, you can proceed as follows.
+
+```env
+ShieldOAuthConfig.google.client_id = Your google client_id key
+ShieldOAuthConfig.google.client_secret = Your google client_secret key
+```
 
 > **Note**
 > By default, there is no file `app/Config/ShieldOAuthConfig`. It is strongly recommended to set the keys to `app/Config/ShieldOAuthConfig`. This behavior will make sure that there will be no problems for the settings you have made in case of update `Shield OAuth`. To create it, you can use the following command:

--- a/src/Libraries/GithubOAuth.php
+++ b/src/Libraries/GithubOAuth.php
@@ -38,8 +38,8 @@ class GithubOAuth extends AbstractOAuth
 
         $this->config        = config('ShieldOAuthConfig');
         $this->callback_url  = base_url('oauth/' . $this->config->call_back_route);
-        $this->client_id     = $this->config->oauthConfigs['github']['client_id'];
-        $this->client_secret = $this->config->oauthConfigs['github']['client_secret'];
+        $this->client_id     = env('ShieldOAuthConfig.github.client_id', $this->config->oauthConfigs['github']['client_id']);
+        $this->client_secret = env('ShieldOAuthConfig.github.client_secret', $this->config->oauthConfigs['github']['client_secret']);
     }
 
     public function makeGoLink(string $state): string

--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -38,8 +38,8 @@ class GoogleOAuth extends AbstractOAuth
 
         $this->config        = config('ShieldOAuthConfig');
         $this->callback_url  = base_url('oauth/' . $this->config->call_back_route);
-        $this->client_id     = $this->config->oauthConfigs['google']['client_id'];
-        $this->client_secret = $this->config->oauthConfigs['google']['client_secret'];
+        $this->client_id     = env('ShieldOAuthConfig.google.client_id', $this->config->oauthConfigs['google']['client_id']);
+        $this->client_secret = env('ShieldOAuthConfig.google.client_secret', $this->config->oauthConfigs['google']['client_secret']);
     }
 
     public function makeGoLink(string $state): string


### PR DESCRIPTION
close #99 
This PR allows you to set the keys in file **.env**. Example:

```env
ShieldOAuthConfig.google.client_id = your google client_id key
ShieldOAuthConfig.google.client_secret = Your google client_secret  key
```
