### PR TITLE
feat: use config file in the custom namespace

### DIFF
--- a/docs/add_other_oauth.md
+++ b/docs/add_other_oauth.md
@@ -205,20 +205,23 @@ declare(strict_types=1);
 
 namespace App\Libraries\ShieldOAuth;
 
+use CodeIgniter\HTTP\CURLRequest;
+use Config\Services;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 use Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth;
 use Exception;
 
 class YahooOAuth extends AbstractOAuth
 {
     // https://developer.yahoo.com/oauth2/guide/flows_authcode/#refresh-token-label
-    static private $API_CODE_URL      = 'https://api.login.yahoo.com/oauth2/request_auth';
-    static private $API_TOKEN_URL     = 'https://api.login.yahoo.com/oauth2/get_token';
-    static private $API_USER_INFO_URL = 'https://api.login.yahoo.com/openid/v1/userinfo';
-    static private $APPLICATION_NAME  = 'ShieldOAuth';
+    private static string $API_CODE_URL      = 'https://api.login.yahoo.com/oauth2/request_auth';
+    private static string $API_TOKEN_URL     = 'https://api.login.yahoo.com/oauth2/get_token';
+    private static string $API_USER_INFO_URL = 'https://api.login.yahoo.com/openid/v1/userinfo';
+    private static string $APPLICATION_NAME  = 'ShieldOAuth';
 
     protected string $token;
-    protected $client;
-    protected $config;
+    protected CURLRequest $client;
+    protected ShieldOAuthConfig $config;
     protected string $client_id;
     protected string $client_secret;
     protected string $callback_url;
@@ -226,7 +229,7 @@ class YahooOAuth extends AbstractOAuth
     public function __construct(string $token = '')
     {
         $this->token  = $token;
-        $this->client = \Config\Services::curlrequest();
+        $this->client = Services::curlrequest();
 
         $this->config        = config('ShieldOAuthConfig');
         $this->callback_url  = base_url('oauth/' . $this->config->call_back_route);

--- a/src/Database/Migrations/2022-10-20-182737_ShieldOAuth.php
+++ b/src/Database/Migrations/2022-10-20-182737_ShieldOAuth.php
@@ -27,7 +27,7 @@ class ShieldOAuth extends Migration
         parent::__construct();
 
         /** @var ShieldOAuthConfig $config */
-        $config           = config(ShieldOAuthConfig::class);
+        $config           = config('ShieldOAuthConfig');
         $this->first_name = $config->usersColumnsName['first_name'];
         $this->last_name  = $config->usersColumnsName['last_name'];
         $this->avatar     = $config->usersColumnsName['avatar'];

--- a/src/Libraries/GithubOAuth.php
+++ b/src/Libraries/GithubOAuth.php
@@ -15,9 +15,9 @@ namespace Datamweb\ShieldOAuth\Libraries;
 
 use CodeIgniter\HTTP\CURLRequest;
 use Config\Services;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 use Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth;
 use Exception;
-use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 
 class GithubOAuth extends AbstractOAuth
 {

--- a/src/Libraries/GithubOAuth.php
+++ b/src/Libraries/GithubOAuth.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\CURLRequest;
 use Config\Services;
 use Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth;
 use Exception;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 
 class GithubOAuth extends AbstractOAuth
 {
@@ -26,7 +27,7 @@ class GithubOAuth extends AbstractOAuth
     private static string $APPLICATION_NAME = 'ShieldOAuth';
     protected string $token;
     protected CURLRequest $client;
-    protected ?object $config = null;
+    protected ShieldOAuthConfig $config;
     protected string $client_id;
     protected string $client_secret;
     protected string $callback_url;

--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\CURLRequest;
 use Config\Services;
 use Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth;
 use Exception;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 
 class GoogleOAuth extends AbstractOAuth
 {
@@ -26,7 +27,7 @@ class GoogleOAuth extends AbstractOAuth
     private static string $APPLICATION_NAME  = 'ShieldOAuth';
     protected string $token;
     protected CURLRequest $client;
-    protected ?object $config = null;
+    protected ShieldOAuthConfig $config;
     protected string $client_id;
     protected string $client_secret;
     protected string $callback_url;

--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -15,9 +15,9 @@ namespace Datamweb\ShieldOAuth\Libraries;
 
 use CodeIgniter\HTTP\CURLRequest;
 use Config\Services;
+use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 use Datamweb\ShieldOAuth\Libraries\Basic\AbstractOAuth;
 use Exception;
-use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig;
 
 class GoogleOAuth extends AbstractOAuth
 {

--- a/src/Models/ShieldOAuthModel.php
+++ b/src/Models/ShieldOAuthModel.php
@@ -23,7 +23,7 @@ class ShieldOAuthModel extends UserModel
         parent::initialize();
 
         /** @var ShieldOAuthConfig $config */
-        $config = config(ShieldOAuthConfig::class);
+        $config = config('ShieldOAuthConfig');
 
         // Merge properties with parent
         $this->allowedFields = array_merge($this->allowedFields, [


### PR DESCRIPTION
See #104 
This PR helps config file to be considered in the custom namespace.
For example :

Add **app/Config/Autoload.php** 
```php
    public $psr4 = [
        // ...
        'MyShieldOauth' => APPPATH . 'ThirdParty\ShieldOauth'
    ];
```
Add **app\ThirdParty\ShieldOauth\Config\ShieldOAuthConfig.php** :
```php
<?php

declare(strict_types=1);

/**
 * This file is part of Shield OAuth.
 *
 * (c) Datamweb <pooya_parsa_dadashi@yahoo.com>
 *
 * For the full copyright and license information, please view
 * the LICENSE file that was distributed with this source code.
 */

namespace MyShieldOauth\Config;

use Datamweb\ShieldOAuth\Config\ShieldOAuthConfig as OAuthConfig;

class ShieldOAuthConfig extends OAuthConfig
{
    /**
     * --------------------------------------------------------------------------
     * OAuth Configs
     * --------------------------------------------------------------------------
     *
     * Set keys and active any OAuth
     *
     * Here you can set the keys received from any OAuth servers.
     * for more information on getting keys:
     *
     * @see https://github.com/datamweb/shield-oauth/blob/develop/docs/get_keys.md
     *
     * @var array<string, array<string, bool|string>>
     */
    public array $oauthConfigs = [
        'github' => [
            'client_id'     => 'Get it from GitHub',
            'client_secret' => 'Get it from GitHub',

            'allow_login' => true,
        ],
        'google' => [
            'client_id'     => 'Get it from Google',
            'client_secret' => 'Get it from Google',

            'allow_login' => true,
        ],
        // 'yahoo' => [
        //     'client_id'     => 'Get it from Yahoo',
        //     'client_secret' => 'Get it from Yahoo',

        //     'allow_login' => true,
        // ],
    ];

    /**
     * --------------------------------------------------------------------------
     * Users Columns Name
     * --------------------------------------------------------------------------
     * If you use different names for the columns in the users table, use the following settings.
     *
     * Data of Table "users":
     * +----+----------+--------+...+------------+-----------+--------+
     * | id | username | status |...| first_name | last_name | avatar |
     * +----+----------+--------+...+------------+-----------+--------+
     * In fact, you set in which column the information received from the OAuth services should be recorded.
     * For example, the first name received from OAuth should be recorded in column 'first_name' of the 'users' table shield.
     * NOTE :
     *       This is suitable for those who have already installed the shield and created their own columns.
     *       In this case, there is no need to execute `php spark migrate -n Datamweb\ShieldOAuth`.
     *       Just set the following values with your table columns.
     *
     * @var array<string, string>
     */
    public array $usersColumnsName = [
        'first_name' => 'first_name',
        'last_name'  => 'last_name',
        'avatar'     => 'avatar',
    ];

    /**
     * --------------------------------------------------------------------------
     * Syncing User Info
     * --------------------------------------------------------------------------
     * Turn ON/OFF user data update
     *
     * If the user is already registered, by default when trying to login, their
     * information will be synchronized. If you want to cancel it, set to false.
     */
    public bool $syncingUserInfo = true;

    /**
     * --------------------------------------------------------------------------
     * Call Back Route
     * --------------------------------------------------------------------------
     * Set your custom call-back name
     *
     * When the user login with his profile, the OAuth server directs him to the following path.
     * So change this value only when you need to customize it.
     * By default, it returns to the following path:
     *      http://localhost:8080/oauth/call-back
     */
    public string $call_back_route = 'call-back';
}

```
These items are important to work properly.
1. The **ShieldOAuthConfig.php** file should not be available **app\Config\ShieldOAuthConfig.php**.(If there is, delete it.)
2. If you are using version CI4.5.0, this process will not work properly, due to a bug (See #https://github.com/codeigniter4/CodeIgniter4/pull/8745).


