### PR TITLE
fix: [BUG] Undefined property: stdClass::$family_name

### DIFF
--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -96,7 +96,7 @@ class GoogleOAuth extends AbstractOAuth
         if ($nameOfProcess === 'syncingUserInfo') {
             return [
                 $this->config->usersColumnsName['first_name'] => $userInfo->name,
-                $this->config->usersColumnsName['last_name']  => $userInfo->family_name,
+                $this->config->usersColumnsName['last_name']  => $userInfo->family_name ?? null,
                 $this->config->usersColumnsName['avatar']     => $userInfo->picture,
             ];
         }


### PR DESCRIPTION
fix #109 
Some users leave their last_name/family_name blank when creating a google account especially old account, so I added a little condition to avoid exception errors