### PR TITLE
feat: add 'allow_register' to $oauthConfigs for drivers

### DIFF
--- a/docs/add_other_oauth.md
+++ b/docs/add_other_oauth.md
@@ -36,7 +36,8 @@ public array $oauthConfigs = [
         'client_id'     => 'Get this from the OAuth server',
         'client_secret' => 'Get this from the OAuth server',
 
-        'allow_login' => true
+        'allow_login'    => true,
+        'allow_register' => true,
     ],
 ];
 
@@ -163,7 +164,8 @@ public array $oauthConfigs = [
         'client_id'     => 'Get this from the OAuth server',
         'client_secret' => 'Get this from the OAuth server',
 
-        'allow_login' => true
+        'allow_login'    => true,
+        'allow_register' => true,
     ],
     //...
 ];

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -33,16 +33,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Controllers\\\\OAuthController\\:\\:syncingUserInfo\\(\\) has parameter \\$find with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Controllers\\\\OAuthController\\:\\:syncingUserInfo\\(\\) has parameter \\$updateFildes with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Controllers/OAuthController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Datamweb\\\\ShieldOAuth\\\\Libraries\\\\Basic\\\\AbstractOAuth\\:\\:fetchAccessTokenWithAuthCode\\(\\) has parameter \\$allGet with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Libraries/Basic/AbstractOAuth.php',

--- a/src/Commands/Generators/NewShieldOauthGenerator.php
+++ b/src/Commands/Generators/NewShieldOauthGenerator.php
@@ -147,7 +147,8 @@ class NewShieldOauthGenerator extends BaseCommand
             'client_id' => 'Get it from {$oauthName}',
             'client_secret' => 'Get it from {$oauthName}',
 
-            'allow_login' => true,
+            'allow_login'    => true,
+            'allow_register' => true,
         ],";
 
         // Setup the process of adding the code to the config file

--- a/src/Config/ShieldOAuthConfig.php
+++ b/src/Config/ShieldOAuthConfig.php
@@ -42,7 +42,8 @@ class ShieldOAuthConfig extends BaseConfig
             'client_id'     => 'Get it from Google',
             'client_secret' => 'Get it from Google',
 
-            'allow_login' => true,
+            'allow_login'   => true,
+            'allow_register'=> true,
         ],
         // 'yahoo' => [
         //     'client_id'     => 'Get it from Yahoo',

--- a/src/Config/ShieldOAuthConfig.php
+++ b/src/Config/ShieldOAuthConfig.php
@@ -43,7 +43,7 @@ class ShieldOAuthConfig extends BaseConfig
             'client_secret' => 'Get it from Google',
 
             'allow_login'    => true,
-            'allow_register' => false,
+            'allow_register' => true,
         ],
         // 'yahoo' => [
         //     'client_id'     => 'Get it from Yahoo',

--- a/src/Config/ShieldOAuthConfig.php
+++ b/src/Config/ShieldOAuthConfig.php
@@ -36,7 +36,8 @@ class ShieldOAuthConfig extends BaseConfig
             'client_id'     => 'Get it from GitHub',
             'client_secret' => 'Get it from GitHub',
 
-            'allow_login' => true,
+            'allow_login'    => true,
+            'allow_register' => true,
         ],
         'google' => [
             'client_id'     => 'Get it from Google',
@@ -49,7 +50,8 @@ class ShieldOAuthConfig extends BaseConfig
         //     'client_id'     => 'Get it from Yahoo',
         //     'client_secret' => 'Get it from Yahoo',
 
-        //     'allow_login' => true,
+        //     'allow_login'    => true,
+        //     'allow_register' => true,
         // ],
     ];
 

--- a/src/Config/ShieldOAuthConfig.php
+++ b/src/Config/ShieldOAuthConfig.php
@@ -42,8 +42,8 @@ class ShieldOAuthConfig extends BaseConfig
             'client_id'     => 'Get it from Google',
             'client_secret' => 'Get it from Google',
 
-            'allow_login'   => true,
-            'allow_register'=> true,
+            'allow_login'    => true,
+            'allow_register' => false,
         ],
         // 'yahoo' => [
         //     'client_id'     => 'Get it from Yahoo',

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -139,7 +139,7 @@ class OAuthController extends BaseController implements ControllersInterface
     /**
      * Syncs user information based on provided fields.
      *
-     * @param array<string, string> $find              Array containing criteria to find the user
+     * @param array<string, string>      $find         Array containing criteria to find the user
      * @param array<string, string|null> $updateFields Fields to update for the user
      *
      * @return int The ID of the user whose information is synced

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -136,15 +136,7 @@ class OAuthController extends BaseController implements ControllersInterface
         return $findUser !== null;
     }
 
-    /**
-     * Syncs user information based on provided fields.
-     *
-     * @param array<string, Find> $find
-     * @param array<string, Updatefields> $updateFields
-     *
-     * @return int The ID of the user whose information is synced
-     */
-    private function syncingUserInfo(array $find = [], array $updateFields = []): int
+    private function syncingUserInfo(array $find = [], array $updateFields = []): int // @phpstan-ignore-line
     {
         $users = model('ShieldOAuthModel');
         $user  = $users->findByCredentials($find);

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -136,7 +136,14 @@ class OAuthController extends BaseController implements ControllersInterface
         return $findUser !== null;
     }
 
-    private function syncingUserInfo(array $find = [], array $updateFields = []): int // @phpstan-ignore-line
+    /**
+     * Syncs user information based on provided fields.
+     *
+     * @param array<string, mixed> $find           Array containing criteria to find the user.
+     * @param array<string, mixed> $updateFields   Fields to update for the user.
+     * @return int                                 The ID of the user whose information is synced.
+     */
+    private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {
         $users = model('ShieldOAuthModel');
         $user  = $users->findByCredentials($find);

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -143,7 +143,7 @@ class OAuthController extends BaseController implements ControllersInterface
 
         $syncingUserInfo = config('ShieldOAuthConfig')->syncingUserInfo;
         if ($syncingUserInfo === true) {
-            $user->fill($updateFildes);
+            $user->fill($updateFields);
         }
         $users->save($user);
 

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -83,6 +83,7 @@ class OAuthController extends BaseController implements ControllersInterface
 
          // Create new user if credentials not exist or let users register themselves
         if ($this->checkExistenceUser($find) === false) {
+
             // Check config setting first to see if it can register automatically ?
             if (config('ShieldOAuthConfig')->oauthConfigs[$oauthName]['allow_register'] === false) {
                 return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.account_not_found'));

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -80,14 +80,14 @@ class OAuthController extends BaseController implements ControllersInterface
 
             $userid = $this->syncingUserInfo($find, $updateFildes);
         }
-        
+
          // Create new user if credentials not exist or let users register themselves
         if ($this->checkExistenceUser($find) === false) {
             // Check config setting first to see if it can register automatically ?
             if (config('ShieldOAuthConfig')->oauthConfigs[$oauthName]['allow_register'] === false) {
                 return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.account_not_found'));
             }
-            
+
             helper('text');
             $users = model('ShieldOAuthModel');
             // new user

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -75,7 +75,7 @@ class OAuthController extends BaseController implements ControllersInterface
 
         $find = ['email' => $userInfo->email];
 
-        if ($this->checkExistenceUser($find) === true) {
+        if ($this->checkExistenceUser($find)) {
             $updateFildes = $oauthClass->getColumnsName('syncingUserInfo', $userInfo);
 
             $userid = $this->syncingUserInfo($find, $updateFildes);

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -77,10 +77,11 @@ class OAuthController extends BaseController implements ControllersInterface
 
         if ($this->checkExistenceUser($find)) {
             $updateFields = $oauthClass->getColumnsName('syncingUserInfo', $userInfo);
+
             $userid = $this->syncingUserInfo($find, $updateFields);
         }
 
-         // Create new user if credentials not exist or let users register themselves
+        // Create new user if credentials not exist or let users register themselves
         if ($this->checkExistenceUser($find) === false) {
 
             // Check config setting first to see if it can register automatically ?

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -139,10 +139,10 @@ class OAuthController extends BaseController implements ControllersInterface
     /**
      * Syncs user information based on provided fields.
      *
-     * @param array $find           Array containing criteria to find the user
-     * @param array $updateFields   Fields to update for the user
+     * @param array<string, Find> $find
+     * @param array<string, Updatefields> $updateFields
      *
-     * @return int                  The ID of the user whose information is synced
+     * @return int The ID of the user whose information is synced
      */
     private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -141,6 +141,7 @@ class OAuthController extends BaseController implements ControllersInterface
      *
      * @param array $find           Array containing criteria to find the user.
      * @param array $updateFields   Fields to update for the user.
+     *
      * @return int                  The ID of the user whose information is synced.
      */
     private function syncingUserInfo(array $find = [], array $updateFields = []): int

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -76,9 +76,8 @@ class OAuthController extends BaseController implements ControllersInterface
         $find = ['email' => $userInfo->email];
 
         if ($this->checkExistenceUser($find)) {
-            $updateFildes = $oauthClass->getColumnsName('syncingUserInfo', $userInfo);
-
-            $userid = $this->syncingUserInfo($find, $updateFildes);
+            $updateFields = $oauthClass->getColumnsName('syncingUserInfo', $userInfo);
+            $userid = $this->syncingUserInfo($find, $updateFields);
         }
 
          // Create new user if credentials not exist or let users register themselves
@@ -137,7 +136,7 @@ class OAuthController extends BaseController implements ControllersInterface
         return $findUser !== null;
     }
 
-    private function syncingUserInfo(array $find = [], array $updateFildes = []): int
+    private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {
         $users = model('ShieldOAuthModel');
         $user  = $users->findByCredentials($find);

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -136,6 +136,13 @@ class OAuthController extends BaseController implements ControllersInterface
         return $findUser !== null;
     }
 
+    /**
+     * Syncs user information based on provided fields.
+     *
+     * @param array $find           Array containing criteria to find the user.
+     * @param array $updateFields   Fields to update for the user.
+     * @return int                  The ID of the user whose information is synced.
+     */
     private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {
         $users = model('ShieldOAuthModel');

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -139,10 +139,10 @@ class OAuthController extends BaseController implements ControllersInterface
     /**
      * Syncs user information based on provided fields.
      *
-     * @param array $find           Array containing criteria to find the user.
-     * @param array $updateFields   Fields to update for the user.
-     *                              Missing type for iterable values in $updateFields array.
-     * @return int                  The ID of the user whose information is synced.
+     * @param array $find           Array containing criteria to find the user
+     * @param array $updateFields   Fields to update for the user
+     *
+     * @return int                  The ID of the user whose information is synced
      */
     private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -139,7 +139,7 @@ class OAuthController extends BaseController implements ControllersInterface
     /**
      * Syncs user information based on provided fields.
      *
-     * @param array<string, string> $find         Array containing criteria to find the user
+     * @param array<string, string> $find              Array containing criteria to find the user
      * @param array<string, string|null> $updateFields Fields to update for the user
      *
      * @return int The ID of the user whose information is synced

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -80,8 +80,14 @@ class OAuthController extends BaseController implements ControllersInterface
 
             $userid = $this->syncingUserInfo($find, $updateFildes);
         }
-
+        
+         // Create new user if credentials not exist or let users register themselves
         if ($this->checkExistenceUser($find) === false) {
+            // Check config setting first to see if it can register automatically ?
+            if (config('ShieldOAuthConfig')->oauthConfigs[$oauthName]['allow_register'] === false) {
+                return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.account_not_found'));
+            }
+            
             helper('text');
             $users = model('ShieldOAuthModel');
             // new user

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -144,7 +144,7 @@ class OAuthController extends BaseController implements ControllersInterface
      *
      * @return int The ID of the user whose information is synced
      */
-    private function syncingUserInfo(array $find = [], array $updateFields = []): int // @phpstan-ignore-line
+    private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {
         $users = model('ShieldOAuthModel');
         $user  = $users->findByCredentials($find);

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -144,7 +144,7 @@ class OAuthController extends BaseController implements ControllersInterface
      *
      * @return int The ID of the user whose information is synced
      */
-    private function syncingUserInfo(array $find = [], array $updateFields = []): int
+    private function syncingUserInfo(array $find = [], array $updateFields = []): int // @phpstan-ignore-line
     {
         $users = model('ShieldOAuthModel');
         $user  = $users->findByCredentials($find);

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -139,8 +139,8 @@ class OAuthController extends BaseController implements ControllersInterface
     /**
      * Syncs user information based on provided fields.
      *
-     * @param array<string, mixed> $find         Array containing criteria to find the user
-     * @param array<string, mixed> $updateFields Fields to update for the user
+     * @param array<string, string> $find         Array containing criteria to find the user
+     * @param array<string, string|null> $updateFields Fields to update for the user
      *
      * @return int The ID of the user whose information is synced
      */

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -141,7 +141,7 @@ class OAuthController extends BaseController implements ControllersInterface
      *
      * @param array $find           Array containing criteria to find the user.
      * @param array $updateFields   Fields to update for the user.
-     *
+     *                              Missing type for iterable values in $updateFields array.
      * @return int                  The ID of the user whose information is synced.
      */
     private function syncingUserInfo(array $find = [], array $updateFields = []): int

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -139,9 +139,10 @@ class OAuthController extends BaseController implements ControllersInterface
     /**
      * Syncs user information based on provided fields.
      *
-     * @param array<string, mixed> $find           Array containing criteria to find the user.
-     * @param array<string, mixed> $updateFields   Fields to update for the user.
-     * @return int                                 The ID of the user whose information is synced.
+     * @param array<string, mixed> $find         Array containing criteria to find the user
+     * @param array<string, mixed> $updateFields Fields to update for the user
+     *
+     * @return int The ID of the user whose information is synced
      */
     private function syncingUserInfo(array $find = [], array $updateFields = []): int
     {

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -83,8 +83,7 @@ class OAuthController extends BaseController implements ControllersInterface
 
         // Create new user if credentials not exist or let users register themselves
         if ($this->checkExistenceUser($find) === false) {
-
-            // Check config setting first to see if it can register automatically ?
+            // Check config setting first to see if it can register automatically or not
             if (config('ShieldOAuthConfig')->oauthConfigs[$oauthName]['allow_register'] === false) {
                 return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.account_not_found'));
             }

--- a/src/Language/en/ShieldOAuthLang.php
+++ b/src/Language/en/ShieldOAuthLang.php
@@ -18,6 +18,7 @@ return [
     'Callback' => [
         'oauth_class_not_set' => 'An error occurred, it seems that the OAuth Class is not set.',
         'anti_forgery'        => 'Your request has been detected as fake. we are sorry!',
+        'account_not_found'   => 'Your account not found. Please register first!',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fa/ShieldOAuthLang.php
+++ b/src/Language/fa/ShieldOAuthLang.php
@@ -18,6 +18,7 @@ return [
     'Callback' => [
         'oauth_class_not_set' => 'خطای رخ داد، به نظر میرسد کلاس OAuth مورد نظر به درستی تنظیم نشده است.',
         'anti_forgery'        => 'متاسفانه، تلاش شما ، یک درخواست جعلی تشخیص داده شد.',
+        'account_not_found'   => '(To be translated) Your account not found. Please register first!',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fa/ShieldOAuthLang.php
+++ b/src/Language/fa/ShieldOAuthLang.php
@@ -18,7 +18,7 @@ return [
     'Callback' => [
         'oauth_class_not_set' => 'خطای رخ داد، به نظر میرسد کلاس OAuth مورد نظر به درستی تنظیم نشده است.',
         'anti_forgery'        => 'متاسفانه، تلاش شما ، یک درخواست جعلی تشخیص داده شد.',
-        'account_not_found'   => '(To be translated) Your account not found. Please register first!',
+        'account_not_found'   => 'اکانت پیدا نشد. لطفا ابتدا ثبت نام کنید!',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fr/ShieldOAuthLang.php
+++ b/src/Language/fr/ShieldOAuthLang.php
@@ -18,6 +18,7 @@ return [
     'Callback' => [
         'oauth_class_not_set' => 'Une erreur s’est produite, il semble que la classe OAuth n’est pas définie.',
         'anti_forgery'        => 'Votre demande a été détectée comme erronée. Nous sommes désolés!',
+        'account_not_found'   => '(To be translated) Your account not found. Please register first!',
     ],
 
     // ShieldOAuthButton in views


### PR DESCRIPTION
See #103 
I made a small addition to this PR to provide option `'allow_register'` on configuration file so that developers can freely choose whether to allow users to auto-register or not. The default value for `'allow_register'`  is set to `true`.