### PR TITLE
feat: Handles deauthentication actions by users.

### DIFF
--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -60,7 +60,7 @@ class OAuthController extends BaseController implements ControllersInterface
         // if permission is denied or was cancelled by user.
         if (isset($allGet['error']) && $allGet['error'] === self::ACCESS_DENIED) {
             $oauth_name = session('oauth_name');
-            $OAuth      = ucwords($oauth_name);
+            $OAuth      = ucfirst($oauth_name);
 
             $oauthName = lang("ShieldOAuthLang.{$OAuth}.{$oauth_name}");
 

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -59,7 +59,10 @@ class OAuthController extends BaseController implements ControllersInterface
 
         // if permission is denied or was cancelled by user.
         if (isset($allGet['error']) && $allGet['error'] === self::ACCESS_DENIED) {
-            $oauthName = ucwords(session('oauth_name'));
+            $oauth_name = session('oauth_name');
+            $OAuth      = ucwords($oauth_name);
+
+            $oauthName = lang("ShieldOAuthLang.{$OAuth}.{$oauth_name}");
 
             return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.access_denied', [$oauthName]));
         }

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -52,16 +52,14 @@ class OAuthController extends BaseController implements ControllersInterface
     public function callBack(): RedirectResponse
     {
         // if user after callback request url
-        if (! session('oauth_name')) {
+        if (! $oauth_name = session('oauth_name')) {
             return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.oauth_class_not_set'));
         }
         $allGet = $this->request->getGet();
 
         // if permission is denied or was cancelled by user.
         if (isset($allGet['error']) && $allGet['error'] === self::ACCESS_DENIED) {
-            $oauth_name = session('oauth_name');
-            $OAuth      = ucfirst($oauth_name);
-
+            $OAuth     = ucfirst($oauth_name);
             $oauthName = lang("ShieldOAuthLang.{$OAuth}.{$oauth_name}");
 
             return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.access_denied', [$oauthName]));

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -21,6 +21,8 @@ use Datamweb\ShieldOAuth\Libraries\Basic\ControllersInterface;
 
 class OAuthController extends BaseController implements ControllersInterface
 {
+    private const ACCESS_DENIED = 'access_denied';
+
     public function redirectOAuth(string $oauthName): RedirectResponse
     {
         // if user login
@@ -54,6 +56,11 @@ class OAuthController extends BaseController implements ControllersInterface
             return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.oauth_class_not_set'));
         }
         $allGet = $this->request->getGet();
+
+        // if permission is denied or was cancelled by user.
+        if (isset($allGet['error']) && $allGet['error'] === self::ACCESS_DENIED) {
+            return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.access_denied'));
+        }
 
         // if api have error
         if (isset($allGet['error'])) {

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -59,7 +59,9 @@ class OAuthController extends BaseController implements ControllersInterface
 
         // if permission is denied or was cancelled by user.
         if (isset($allGet['error']) && $allGet['error'] === self::ACCESS_DENIED) {
-            return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.access_denied'));
+            $oauthName = ucwords(session('oauth_name'));
+
+            return redirect()->to(config('Auth')->logoutRedirect())->with('error', lang('ShieldOAuthLang.Callback.access_denied', [$oauthName]));
         }
 
         // if api have error

--- a/src/Language/en/ShieldOAuthLang.php
+++ b/src/Language/en/ShieldOAuthLang.php
@@ -19,7 +19,7 @@ return [
         'oauth_class_not_set' => 'An error occurred, it seems that the OAuth Class is not set.',
         'anti_forgery'        => 'Your request has been detected as fake. we are sorry!',
         'account_not_found'   => 'There is no account registered with the email "{0}".',
-        'access_denied'       => 'Authentication cancelled.',
+        'access_denied'       => 'Authentication cancelled! You declined {0} permissions.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/en/ShieldOAuthLang.php
+++ b/src/Language/en/ShieldOAuthLang.php
@@ -19,6 +19,7 @@ return [
         'oauth_class_not_set' => 'An error occurred, it seems that the OAuth Class is not set.',
         'anti_forgery'        => 'Your request has been detected as fake. we are sorry!',
         'account_not_found'   => 'There is no account registered with the email "{0}".',
+        'access_denied'       => 'Authentication cancelled.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fa/ShieldOAuthLang.php
+++ b/src/Language/fa/ShieldOAuthLang.php
@@ -19,7 +19,7 @@ return [
         'oauth_class_not_set' => 'خطای رخ داد، به نظر میرسد کلاس OAuth مورد نظر به درستی تنظیم نشده است.',
         'anti_forgery'        => 'متاسفانه، تلاش شما ، یک درخواست جعلی تشخیص داده شد.',
         'account_not_found'   => 'هیچ حسابی با ایمیل "{0}" ثبت نشده است.',
-        'access_denied'       => '(To be translated) Authentication cancelled! You declined {0} permissions.',
+        'access_denied'       => 'تأیید اعتبار لغو شد! شما دسترسی‌های {0} را رد کردید.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fa/ShieldOAuthLang.php
+++ b/src/Language/fa/ShieldOAuthLang.php
@@ -20,7 +20,6 @@ return [
         'anti_forgery'        => 'متاسفانه، تلاش شما ، یک درخواست جعلی تشخیص داده شد.',
         'account_not_found'   => 'هیچ حسابی با ایمیل "{0}" ثبت نشده است.',
         'access_denied'       => '(To be translated) Authentication cancelled.',
-
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fa/ShieldOAuthLang.php
+++ b/src/Language/fa/ShieldOAuthLang.php
@@ -19,6 +19,8 @@ return [
         'oauth_class_not_set' => 'خطای رخ داد، به نظر میرسد کلاس OAuth مورد نظر به درستی تنظیم نشده است.',
         'anti_forgery'        => 'متاسفانه، تلاش شما ، یک درخواست جعلی تشخیص داده شد.',
         'account_not_found'   => 'هیچ حسابی با ایمیل "{0}" ثبت نشده است.',
+        'access_denied'       => '(To be translated) Authentication cancelled.',
+
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fa/ShieldOAuthLang.php
+++ b/src/Language/fa/ShieldOAuthLang.php
@@ -19,7 +19,7 @@ return [
         'oauth_class_not_set' => 'خطای رخ داد، به نظر میرسد کلاس OAuth مورد نظر به درستی تنظیم نشده است.',
         'anti_forgery'        => 'متاسفانه، تلاش شما ، یک درخواست جعلی تشخیص داده شد.',
         'account_not_found'   => 'هیچ حسابی با ایمیل "{0}" ثبت نشده است.',
-        'access_denied'       => '(To be translated) Authentication cancelled.',
+        'access_denied'       => '(To be translated) Authentication cancelled! You declined {0} permissions.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fr/ShieldOAuthLang.php
+++ b/src/Language/fr/ShieldOAuthLang.php
@@ -19,6 +19,7 @@ return [
         'oauth_class_not_set' => 'Une erreur s’est produite, il semble que la classe OAuth n’est pas définie.',
         'anti_forgery'        => 'Votre demande a été détectée comme erronée. Nous sommes désolés!',
         'account_not_found'   => 'Il n\'y a pas de compte enregistré avec l\'email "{0}".',
+        'access_denied'       => '(To be translated) Authentication cancelled.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fr/ShieldOAuthLang.php
+++ b/src/Language/fr/ShieldOAuthLang.php
@@ -19,7 +19,7 @@ return [
         'oauth_class_not_set' => 'Une erreur s’est produite, il semble que la classe OAuth n’est pas définie.',
         'anti_forgery'        => 'Votre demande a été détectée comme erronée. Nous sommes désolés!',
         'account_not_found'   => 'Il n\'y a pas de compte enregistré avec l\'email "{0}".',
-        'access_denied'       => '(To be translated) Authentication cancelled! You declined {0} permissions.',
+        'access_denied'       => 'Authentification annulée ! Vous avez refusé les autorisations {0}.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/fr/ShieldOAuthLang.php
+++ b/src/Language/fr/ShieldOAuthLang.php
@@ -19,7 +19,7 @@ return [
         'oauth_class_not_set' => 'Une erreur s’est produite, il semble que la classe OAuth n’est pas définie.',
         'anti_forgery'        => 'Votre demande a été détectée comme erronée. Nous sommes désolés!',
         'account_not_found'   => 'Il n\'y a pas de compte enregistré avec l\'email "{0}".',
-        'access_denied'       => '(To be translated) Authentication cancelled.',
+        'access_denied'       => '(To be translated) Authentication cancelled! You declined {0} permissions.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/id/ShieldOAuthLang.php
+++ b/src/Language/id/ShieldOAuthLang.php
@@ -19,7 +19,7 @@ return [
         'oauth_class_not_set' => 'Terjadi kesalahan, sepertinya class OAuth tidak terpasang.',
         'anti_forgery'        => 'Maaf, permintaan Anda terdeteksi tidak valid!',
         'account_not_found'   => 'Tidak ada akun yang terdaftar dengan email "{0}".',
-        'access_denied'       => 'Autentikasi dibatalkan.',
+        'access_denied'       => 'Autentikasi dibatalkan! Anda menolak izin {0}.',
     ],
 
     // ShieldOAuthButton in views

--- a/src/Language/id/ShieldOAuthLang.php
+++ b/src/Language/id/ShieldOAuthLang.php
@@ -19,6 +19,7 @@ return [
         'oauth_class_not_set' => 'Terjadi kesalahan, sepertinya class OAuth tidak terpasang.',
         'anti_forgery'        => 'Maaf, permintaan Anda terdeteksi tidak valid!',
         'account_not_found'   => 'Tidak ada akun yang terdaftar dengan email "{0}".',
+        'access_denied'       => 'Autentikasi dibatalkan.',
     ],
 
     // ShieldOAuthButton in views


### PR DESCRIPTION
This PR handles an error when a user cancels a request for additional access to a Google Account. 

Without this check this package will return the error message `ShieldOAuthLang.unknown` which will be difficult for users and developers to understand the exact problem.

### Step to Reproduce
- click Oauth login button
- choose email account if you have multiple account
- click cancel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error handling during the OAuth authentication process with a specific access denial message.
	- Added localized error messages for access denial in multiple languages (English, French, Indonesian, and placeholders for further translations).

- **Bug Fixes**
	- Enhanced user feedback for scenarios where authentication is canceled or access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->