### PR TITLE
docs: update copyright year to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Pooya Parsa Dadashi
+Copyright (c) 2022-2023 Pooya Parsa Dadashi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,10 +24,10 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/datamweb/shield-oauth
       name: GitHub
-  copyright: Copyright &copy; 2023 Pooya Parsa Dadashi
 
 repo_url: https://github.com/datamweb/shield-oauth
 edit_uri: edit/develop/docs/
+copyright: Copyright &copy; 2022-2023 Pooya Parsa Dadashi.
 
 plugins:
   - search


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated copyright years in the `LICENSE` file and `mkdocs.yml` to reflect a range from 2022 to 2023.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->