### PR TITLE
fix: add base branch for open PR

### DIFF
--- a/.github/workflows/auto-update-copyright.yml
+++ b/.github/workflows/auto-update-copyright.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ env.BRANCH_NAME }}
+        base: develop
         title: "docs: update copyright year to ${{ env.CURRENT_YEAR }}."
         body: "This pull request updates the copyright year to ${{ env.CURRENT_YEAR }}."
         labels: "automation,copyright,documentation"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to specify the base branch for copyright updates, improving clarity in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->