### PR TITLE
fix: Ensure banned users are not allowed to log in.

### DIFF
--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -22,7 +22,8 @@ use Datamweb\ShieldOAuth\Libraries\Basic\ControllersInterface;
 class OAuthController extends BaseController implements ControllersInterface
 {
     private const ACCESS_DENIED = 'access_denied';
-    private ?User $userExist;
+
+    private ?User $userExist = null;
 
     public function redirectOAuth(string $oauthName): RedirectResponse
     {


### PR DESCRIPTION
I'm curious, why banned users still can log in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user authentication process to check for banned users before login attempts.
	- Improved logic to prevent self-registration for existing users.

- **Bug Fixes**
	- Resolved issues related to user existence checks during login, ensuring a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->