### PR TITLE
fix: ensure ban check for existing users

### DIFF
--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -111,7 +111,7 @@ class OAuthController extends BaseController implements ControllersInterface
             $users->addToDefaultGroup($user);
         }
 
-        if ($this->userExist->isBanned()) {
+        if ($this->userExist && $this->userExist->isBanned()) {
             return redirect()->to(config('Auth')->logoutRedirect())->with('error', $this->userExist->getBanMessage() ?? lang('Auth.bannedUser'));
         }
 


### PR DESCRIPTION
follow up: #167 

Since we don't use `allow_register`, I haven't had a chance to test its functionality. 
As a result, the `isBanned()` check fails if `allow_register` config is set to `true`. This PR ensures that the check applies only to existing users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the OAuth callback process to prevent potential null reference errors when checking user status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->