### PR TITLE
fix: missing ShieldOAuthConfig key setting

### DIFF
--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -164,7 +164,7 @@ class OAuthController extends BaseController implements ControllersInterface
         $users = model('ShieldOAuthModel');
         $user  = $users->findByCredentials($find);
 
-        if (setting('ShieldOAuthConfig.syncingUserInfo') === true) {
+        if (setting('ShieldOAuthConfig.oauthConfigs')['syncingUserInfo'] === true) {
             $user->fill($updateFields);
         }
 


### PR DESCRIPTION
follow up: #170 
ShieldOAuthConfig key in setting is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the synchronization of user information based on updated configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->