### PR TITLE
Use correct google library property for first-name-only db field.

### DIFF
--- a/src/Libraries/GoogleOAuth.php
+++ b/src/Libraries/GoogleOAuth.php
@@ -96,7 +96,7 @@ class GoogleOAuth extends AbstractOAuth
     {
         if ($nameOfProcess === 'syncingUserInfo') {
             return [
-                $this->config->usersColumnsName['first_name'] => $userInfo->name,
+                $this->config->usersColumnsName['first_name'] => $userInfo->given_name,
                 $this->config->usersColumnsName['last_name']  => $userInfo->family_name ?? null,
                 $this->config->usersColumnsName['avatar']     => $userInfo->picture,
             ];


### PR DESCRIPTION
Addressed issue #177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the user sign-in process so that the first name is now captured accurately, ensuring your profile information is correctly displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->