### PR TITLE
Add the access token to the user session.

### DIFF
--- a/src/Libraries/Basic/AbstractOAuth.php
+++ b/src/Libraries/Basic/AbstractOAuth.php
@@ -28,6 +28,9 @@ abstract class AbstractOAuth
     protected function setToken(string $token): void
     {
         $this->token = $token;
+
+        $session = session(); // session helper is required already by CI Shield, but might not be initialized yet
+        $session->set('oauth_token', $token);
     }
 
     protected function getToken(): string


### PR DESCRIPTION
Add the access token to the user session so that it can be used to make API calls to the same provider elsewhere in the app without requiring additional client authentication flows.

I spent a lot of time looking for the right place to add this. Please suggest if there is a better place.

I also wanted to add a note to the docs highlighting this feature, but couldn't find a smart place for it. Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication session management so that tokens are retained more reliably, leading to a smoother and more consistent login experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->