### PR TITLE
Add 'registration' event trigger from Shield into Oauth

### DIFF
--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Datamweb\ShieldOAuth\Controllers;
 
 use App\Controllers\BaseController;
+use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\LoginModel;
@@ -109,6 +110,9 @@ class OAuthController extends BaseController implements ControllersInterface
             $users->save($user);
             // Add to default group
             $users->addToDefaultGroup($user);
+
+            // Trigger the register event defined by Shield to integrate oauth registrations better
+            Events::trigger('register', $user);
         }
 
         if ($this->userExist && $this->userExist->isBanned()) {


### PR DESCRIPTION
This PR improves OAuth integration with the Shield add-on by causing the Oauth controller to fire the `register` event in the same way that Shield does when a manual registration occurs.

Since this seems like an expected behaviour, I have not added any documentation for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth sign-ups now follow the same post-registration flows as standard sign-ups, ensuring consistent behavior after account creation.
  * Users registering via OAuth can receive the same follow-up actions such as welcome messages, confirmations, or security checks where configured.
  * Improves compatibility with existing registration workflows so downstream processes (notifications, logs, audits) apply uniformly to OAuth accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->